### PR TITLE
Fixes for building on a Windows host

### DIFF
--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -19,8 +19,7 @@ COPY plugins.txt /usr/share/jenkins/plugins.txt
 RUN dos2unix /usr/share/jenkins/plugins.txt
 
 COPY start.sh /tmp/start.sh
-RUN dos2unix /tmp/start.sh
-RUN chmod +x /tmp/start.sh
+RUN dos2unix /tmp/start.sh && chmod +x /tmp/start.sh
 
 RUN /usr/local/bin/plugins.sh /usr/share/jenkins/plugins.txt
 

--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update -qq && apt-get install -qqy \
     curl \
     wget \
     lxc \
-    iptables
+    iptables \
+    dos2unix
 
 RUN wget -qO- https://get.docker.com/ | sh
 
@@ -15,7 +16,11 @@ RUN curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-com
 RUN chmod +x /usr/local/bin/docker-compose
 
 COPY plugins.txt /usr/share/jenkins/plugins.txt
+RUN dos2unix /usr/share/jenkins/plugins.txt
+
 COPY start.sh /tmp/start.sh
+RUN dos2unix /tmp/start.sh
+RUN chmod +x /tmp/start.sh
 
 RUN /usr/local/bin/plugins.sh /usr/share/jenkins/plugins.txt
 


### PR DESCRIPTION
When building the Docker image from a Windows host a couple of files
may result in wrong file mode and end-of-line ending.

Add additional steps in Dockerfile to make sure the files
are properly copied inside the Docker image.

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
